### PR TITLE
Added physical resource ID to request object.

### DIFF
--- a/src/main/java/com/sunrun/cfnresponse/CfnRequest.java
+++ b/src/main/java/com/sunrun/cfnresponse/CfnRequest.java
@@ -11,6 +11,7 @@ public class CfnRequest<T> {
     public String StackId;
     public String RequestId;
     public String LogicalResourceId;
+    public String PhysicalResourceId;
     public String ResourceType;
 
     public T getResourceProperties() {
@@ -48,6 +49,12 @@ public class CfnRequest<T> {
     }
     public void setLogicalResourceId(final String logicalResourceId) {
         LogicalResourceId = logicalResourceId;
+    }
+    public String getPhysicalResourceId() {
+        return PhysicalResourceId;
+    }
+    public void setPhysicalResourceId(final String physicalResourceId) {
+        PhysicalResourceId = physicalResourceId;
     }
     public String getResourceType() {
         return ResourceType;


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html in case of UPDATE/DELETE request types, request includes physical resource ID that can identify existing resource. It's very needed in many update scenarios to update subject of changes.